### PR TITLE
Refactor PWA assets

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -1,0 +1,114 @@
+const API_URL='http://localhost:8010';
+const loginEl=document.getElementById('login');
+const sessionEl=document.getElementById('session');
+const loginForm=document.getElementById('loginForm');
+const loginBtn=document.getElementById('loginBtn');
+const loginUser=document.getElementById('loginUser');
+const loginPass=document.getElementById('loginPass');
+const startBtn=document.getElementById('startBtn');
+const controls=document.getElementById('controls');
+const recordBtn=document.getElementById('recordBtn');
+const finishBtn=document.getElementById('finishBtn');
+const recordingsList=document.getElementById('recordings');
+let token=null,sessionId=null,recorder=null,chunks=[],audioCount=0,isRecording=false,holdTimer=null;
+loginForm.onsubmit=e=>{e.preventDefault();
+    if(!loginUser.value.trim()||!loginPass.value.trim())return;
+    loginBtn.disabled=true;
+    fetch(`${API_URL}/api/v1/auth/login`,{
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body:JSON.stringify({username:loginUser.value,password:loginPass.value})
+    }).then(r=>{loginBtn.disabled=false;return r.ok?r.json():Promise.reject();})
+    .then(data=>{
+        token=data.token;
+        loginEl.classList.add('hidden');
+        sessionEl.classList.remove('hidden');
+        document.body.classList.add('logged-in');
+    }).catch(()=>alert('Ошибка авторизации'));
+};
+startBtn.onclick=()=>{
+    fetch(`${API_URL}/api/v1/appointments/create`,{
+        method:'POST',
+        headers:{'Authorization':`Bearer ${token}`}
+    }).then(r=>r.ok?r.json():Promise.reject())
+    .then(data=>{
+        sessionId=data.appointment_id||data.id||crypto.randomUUID();
+        startBtn.classList.add('hidden');
+        controls.classList.remove('hidden');
+        audioCount=0;
+        recordingsList.innerHTML='';
+    }).catch(()=>alert('Ошибка создания приема'));
+};
+function startRecording(){
+    navigator.mediaDevices.getUserMedia({audio:true}).then(stream=>{
+        recorder=new MediaRecorder(stream);
+        recorder.ondataavailable=e=>{chunks.push(e.data);};
+        recorder.onstop=()=>{
+            const blob=new Blob(chunks,{type:'audio/webm'});
+            chunks=[];
+            addRecording(blob);
+        };
+        recorder.start();
+        isRecording=true;
+        recordBtn.textContent='Стоп';
+    }).catch(()=>alert('Нет доступа к микрофону'));
+}
+function stopRecording(){
+    if(recorder){
+        recorder.stop();
+        isRecording=false;
+        recordBtn.textContent='Запись';
+    }
+}
+function addRecording(blob){
+    const id=++audioCount;
+    const li=document.createElement('li');
+    const meta=document.createElement('div');
+    meta.className='meta';
+    meta.textContent=`${id}. ${new Date().toLocaleTimeString()}`;
+    const audio=document.createElement('audio');
+    audio.controls=true;
+    audio.src=URL.createObjectURL(blob);
+    const status=document.createElement('span');
+    status.className='status';
+    status.textContent='отправка...';
+    li.appendChild(meta);
+    li.appendChild(audio);
+    li.appendChild(status);
+    recordingsList.prepend(li);
+    sendAudio(id,blob,status);
+}
+function sendAudio(id,blob,statusEl){
+    const fd=new FormData();
+    fd.append('number',id);
+    fd.append('appointment_id',sessionId);
+    fd.append('file',blob,`audio_${id}.webm`);
+    fetch(`${API_URL}/api/v1/audio/upload`,{method:'POST',headers:{'Authorization':`Bearer ${token}`},body:fd})
+        .then(r=>r.ok?r.json():Promise.reject())
+        .then(()=>{statusEl.textContent='отправлено';})
+        .catch(()=>{statusEl.textContent='ошибка';});
+}
+finishBtn.onclick=()=>{
+    controls.classList.add('hidden');
+    startBtn.classList.remove('hidden');
+    recordingsList.innerHTML='';
+    alert('Прием завершен');
+};
+recordBtn.addEventListener('pointerdown',e=>{
+    recordBtn.setPointerCapture(e.pointerId);
+    holdTimer=setTimeout(()=>{startRecording();recordBtn.dataset.mode='hold';},200);
+});
+recordBtn.addEventListener('pointerup',e=>{
+    clearTimeout(holdTimer);
+    recordBtn.releasePointerCapture(e.pointerId);
+    if(recordBtn.dataset.mode==='hold'){
+        if(isRecording)stopRecording();
+        recordBtn.dataset.mode='';
+    }else{
+        if(!isRecording)startRecording();
+        else stopRecording();
+    }
+});
+if('serviceWorker' in navigator && location.protocol.startsWith('http')){
+    navigator.serviceWorker.register('/sw.js');
+}

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,0 +1,16 @@
+body{font-family:'Roboto',sans-serif;margin:0;background:#f4f4f4;color:#333;display:flex;justify-content:center;align-items:center;min-height:100vh}
+body.logged-in{align-items:flex-start;padding-top:20px}
+.container{background:#fff;padding:20px;border-radius:8px;box-shadow:0 2px 8px rgba(0,0,0,0.1);width:300px}
+body.logged-in .container{display:flex;flex-direction:column;height:calc(100vh - 40px)}
+h1{text-align:center;font-size:1.4em;margin-bottom:20px}
+button{font-size:1em;padding:10px 20px;margin:5px;width:100%;border:none;border-radius:4px;cursor:pointer}
+button.primary{background:#6200ee;color:#fff}
+button.secondary{background:#f5f5f5}
+#login input,#login button{width:100%;padding:8px;margin:10px 0;box-sizing:border-box}
+.hidden{display:none}
+ul{list-style:none;padding:0;margin-top:15px;overflow-y:auto;flex:1}
+li{margin-bottom:10px}
+audio{width:100%}
+.status{font-size:0.8em;color:#666}
+#controls{position:sticky;top:0;background:#fff;z-index:1}
+.meta{font-size:0.9em;margin-bottom:4px;color:#444}

--- a/index.html
+++ b/index.html
@@ -5,24 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Clinic PWA Demo</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap">
-    <style>
-        body{font-family:'Roboto',sans-serif;margin:0;background:#f4f4f4;color:#333;display:flex;justify-content:center;align-items:center;min-height:100vh}
-        body.logged-in{align-items:flex-start;padding-top:20px}
-        .container{background:#fff;padding:20px;border-radius:8px;box-shadow:0 2px 8px rgba(0,0,0,0.1);width:300px}
-        body.logged-in .container{display:flex;flex-direction:column;height:calc(100vh - 40px)}
-        h1{text-align:center;font-size:1.4em;margin-bottom:20px}
-        button{font-size:1em;padding:10px 20px;margin:5px;width:100%;border:none;border-radius:4px;cursor:pointer}
-        button.primary{background:#6200ee;color:#fff}
-        button.secondary{background:#f5f5f5}
-        #login input,#login button{width:100%;padding:8px;margin:10px 0;box-sizing:border-box}
-        .hidden{display:none}
-        ul{list-style:none;padding:0;margin-top:15px;overflow-y:auto;flex:1}
-        li{margin-bottom:10px}
-        audio{width:100%}
-        .status{font-size:0.8em;color:#666}
-        #controls{position:sticky;top:0;background:#fff;z-index:1}
-        .meta{font-size:0.9em;margin-bottom:4px;color:#444}
-    </style>
+    <link rel="stylesheet" href="assets/style.css">
+    <link rel="manifest" href="manifest.json">
+    <meta http-equiv="Content-Security-Policy" content="connect-src http: https: ws: blob:;">
 </head>
 <body>
 <div class="container">
@@ -43,80 +28,6 @@
         </div>
     </div>
 </div>
-<script>
-const API_URL='http://localhost:8010';
-const loginEl=document.getElementById('login');
-const sessionEl=document.getElementById('session');
-const loginForm=document.getElementById('loginForm');
-const loginBtn=document.getElementById('loginBtn');
-const loginUser=document.getElementById('loginUser');
-const loginPass=document.getElementById('loginPass');
-const startBtn=document.getElementById('startBtn');
-const controls=document.getElementById('controls');
-const recordBtn=document.getElementById('recordBtn');
-const finishBtn=document.getElementById('finishBtn');
-const recordingsList=document.getElementById('recordings');
-let token=null,sessionId=null,recorder=null,chunks=[],audioCount=0,isRecording=false,holdTimer=null;
-loginForm.onsubmit=e=>{e.preventDefault();
-    if(!loginUser.value.trim()||!loginPass.value.trim())return;
-    loginBtn.disabled=true;
-    fetch(`${API_URL}/api/v1/auth/login`,{
-        method:'POST',
-        headers:{'Content-Type':'application/json'},
-        body:JSON.stringify({username:loginUser.value,password:loginPass.value})
-    }).then(r=>{loginBtn.disabled=false;return r.ok?r.json():Promise.reject();})
-    .then(data=>{
-        token=data.token;
-        loginEl.classList.add('hidden');
-        sessionEl.classList.remove('hidden');
-        document.body.classList.add('logged-in');
-    }).catch(()=>alert('Ошибка авторизации'));
-};
-startBtn.onclick=()=>{
-    fetch(`${API_URL}/api/v1/appointments/create`,{
-        method:'POST',
-        headers:{'Authorization':`Bearer ${token}`}
-    }).then(r=>r.ok?r.json():Promise.reject())
-    .then(data=>{
-        sessionId=data.appointment_id||data.id||crypto.randomUUID();
-        startBtn.classList.add('hidden');
-        controls.classList.remove('hidden');
-        audioCount=0;
-        recordingsList.innerHTML='';
-    }).catch(()=>alert('Ошибка создания приема'));
-};
-function startRecording(){navigator.mediaDevices.getUserMedia({audio:true}).then(stream=>{recorder=new MediaRecorder(stream);recorder.ondataavailable=e=>{chunks.push(e.data);};recorder.onstop=()=>{const blob=new Blob(chunks,{type:'audio/webm'});chunks=[];addRecording(blob);};recorder.start();isRecording=true;recordBtn.textContent='Стоп';}).catch(()=>alert('Нет доступа к микрофону'));}
-function stopRecording(){if(recorder){recorder.stop();isRecording=false;recordBtn.textContent='Запись';}}
-function addRecording(blob){const id=++audioCount;const li=document.createElement('li');const meta=document.createElement('div');meta.className='meta';meta.textContent=`${id}. ${new Date().toLocaleTimeString()}`;const audio=document.createElement('audio');audio.controls=true;audio.src=URL.createObjectURL(blob);const status=document.createElement('span');status.className='status';status.textContent='отправка...';li.appendChild(meta);li.appendChild(audio);li.appendChild(status);recordingsList.prepend(li);sendAudio(id,blob,status);}
-function sendAudio(id,blob,statusEl){
-    const fd=new FormData();
-    fd.append('number',id);
-    fd.append('appointment_id',sessionId);
-    fd.append('file',blob,`audio_${id}.webm`);
-    fetch(`${API_URL}/api/v1/audio/upload`,{method:'POST',headers:{'Authorization':`Bearer ${token}`},body:fd})
-        .then(r=>r.ok?r.json():Promise.reject())
-        .then(()=>{statusEl.textContent='отправлено';})
-        .catch(()=>{statusEl.textContent='ошибка';});
-}
-finishBtn.onclick=()=>{controls.classList.add('hidden');startBtn.classList.remove('hidden');recordingsList.innerHTML='';alert('Прием завершен');};
-recordBtn.addEventListener('pointerdown',e=>{
-    recordBtn.setPointerCapture(e.pointerId);
-    holdTimer=setTimeout(()=>{startRecording();recordBtn.dataset.mode='hold';},200);
-});
-recordBtn.addEventListener('pointerup',e=>{
-    clearTimeout(holdTimer);
-    recordBtn.releasePointerCapture(e.pointerId);
-    if(recordBtn.dataset.mode==='hold'){
-        if(isRecording)stopRecording();
-        recordBtn.dataset.mode='';
-    }else{
-        if(!isRecording)startRecording();
-        else stopRecording();
-    }
-});
-const manifest={"name":"Clinic PWA Demo","short_name":"Clinic","start_url":"./","display":"standalone","theme_color":"#6200ee","background_color":"#ffffff","icons":[{"src":"https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/svg/1f3e5.svg","sizes":"192x192","type":"image/svg+xml"}]};
-const manifestBlob=new Blob([JSON.stringify(manifest)],{type:'application/json'});const manifestURL=URL.createObjectURL(manifestBlob);const link=document.createElement('link');link.rel='manifest';link.href=manifestURL;document.head.appendChild(link);
-if('serviceWorker'in navigator && location.protocol.startsWith('http')){const swBlob=new Blob([`self.addEventListener('install',e=>{self.skipWaiting();e.waitUntil(caches.open('v1').then(c=>c.addAll(['./'])));});self.addEventListener('fetch',e=>{e.respondWith(caches.match(e.request).then(r=>r||fetch(e.request)));});`],{type:'text/javascript'});const swURL=URL.createObjectURL(swBlob);navigator.serviceWorker.register(swURL);} 
-</script>
+<script src="assets/main.js"></script>
 </body>
 </html>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,15 @@
+{
+  "name": "Clinic PWA Demo",
+  "short_name": "Clinic",
+  "start_url": "./",
+  "display": "standalone",
+  "theme_color": "#6200ee",
+  "background_color": "#ffffff",
+  "icons": [
+    {
+      "src": "https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/svg/1f3e5.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,11 @@
+self.addEventListener('install',e=>{
+  self.skipWaiting();
+  e.waitUntil(
+    caches.open('v1').then(c=>c.addAll(['./']))
+  );
+});
+self.addEventListener('fetch',e=>{
+  e.respondWith(
+    caches.match(e.request).then(r=>r||fetch(e.request))
+  );
+});


### PR DESCRIPTION
## Summary
- separate CSS and JS into `assets`
- move service worker and manifest to real files
- simplify HTML to load external assets and set basic CSP

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685c688d0690832da160e1d8a23540c6