### PR TITLE
Implement appointment management UI

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -1,114 +1,238 @@
-const API_URL='http://localhost:8010';
-const loginEl=document.getElementById('login');
-const sessionEl=document.getElementById('session');
-const loginForm=document.getElementById('loginForm');
-const loginBtn=document.getElementById('loginBtn');
-const loginUser=document.getElementById('loginUser');
-const loginPass=document.getElementById('loginPass');
-const startBtn=document.getElementById('startBtn');
-const controls=document.getElementById('controls');
-const recordBtn=document.getElementById('recordBtn');
-const finishBtn=document.getElementById('finishBtn');
-const recordingsList=document.getElementById('recordings');
-let token=null,sessionId=null,recorder=null,chunks=[],audioCount=0,isRecording=false,holdTimer=null;
-loginForm.onsubmit=e=>{e.preventDefault();
-    if(!loginUser.value.trim()||!loginPass.value.trim())return;
-    loginBtn.disabled=true;
-    fetch(`${API_URL}/api/v1/auth/login`,{
-        method:'POST',
-        headers:{'Content-Type':'application/json'},
-        body:JSON.stringify({username:loginUser.value,password:loginPass.value})
-    }).then(r=>{loginBtn.disabled=false;return r.ok?r.json():Promise.reject();})
-    .then(data=>{
-        token=data.token;
-        loginEl.classList.add('hidden');
-        sessionEl.classList.remove('hidden');
-        document.body.classList.add('logged-in');
-    }).catch(()=>alert('Ошибка авторизации'));
+const API_URL = 'http://localhost:8010';
+
+const loginEl = document.getElementById('login');
+const appEl = document.getElementById('app');
+const loginForm = document.getElementById('loginForm');
+const loginBtn = document.getElementById('loginBtn');
+const loginUser = document.getElementById('loginUser');
+const loginPass = document.getElementById('loginPass');
+const usernameEl = document.getElementById('username');
+const logoutBtn = document.getElementById('logoutBtn');
+const createBtn = document.getElementById('createBtn');
+const appointmentsEl = document.getElementById('appointments');
+const appointmentEl = document.getElementById('appointment');
+const appointmentTitle = document.getElementById('appointmentTitle');
+const backBtn = document.getElementById('backBtn');
+const finishBtn = document.getElementById('finishBtn');
+const controls = document.getElementById('controls');
+const recordBtn = document.getElementById('recordBtn');
+const recordingsList = document.getElementById('recordings');
+
+let token = null;
+let currentUser = null;
+let currentAppointment = null;
+let currentStatus = 'pending';
+let recorder = null;
+let chunks = [];
+let audioCount = 0;
+let isRecording = false;
+let holdTimer = null;
+
+loginForm.onsubmit = async (e) => {
+  e.preventDefault();
+  if (!loginUser.value.trim() || !loginPass.value.trim()) return;
+  loginBtn.disabled = true;
+  try {
+    const r = await fetch(`${API_URL}/api/v1/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: loginUser.value, password: loginPass.value })
+    });
+    loginBtn.disabled = false;
+    if (!r.ok) throw new Error();
+    const d = await r.json();
+    token = d.token;
+    currentUser = d.user_id;
+    usernameEl.textContent = currentUser;
+    loginEl.classList.add('hidden');
+    appEl.classList.remove('hidden');
+    document.body.classList.add('logged-in');
+    fetchAppointments();
+  } catch (e) {
+    alert('Ошибка авторизации');
+  }
 };
-startBtn.onclick=()=>{
-    fetch(`${API_URL}/api/v1/appointments/create`,{
-        method:'POST',
-        headers:{'Authorization':`Bearer ${token}`}
-    }).then(r=>r.ok?r.json():Promise.reject())
-    .then(data=>{
-        sessionId=data.appointment_id||data.id||crypto.randomUUID();
-        startBtn.classList.add('hidden');
-        controls.classList.remove('hidden');
-        audioCount=0;
-        recordingsList.innerHTML='';
-    }).catch(()=>alert('Ошибка создания приема'));
+
+logoutBtn.onclick = () => {
+  token = null;
+  currentUser = null;
+  loginEl.classList.remove('hidden');
+  appEl.classList.add('hidden');
+  document.body.classList.remove('logged-in');
 };
-function startRecording(){
-    navigator.mediaDevices.getUserMedia({audio:true}).then(stream=>{
-        recorder=new MediaRecorder(stream);
-        recorder.ondataavailable=e=>{chunks.push(e.data);};
-        recorder.onstop=()=>{
-            const blob=new Blob(chunks,{type:'audio/webm'});
-            chunks=[];
-            addRecording(blob);
-        };
-        recorder.start();
-        isRecording=true;
-        recordBtn.textContent='Стоп';
-    }).catch(()=>alert('Нет доступа к микрофону'));
+
+async function fetchAppointments() {
+  appointmentsEl.innerHTML = '';
+  try {
+    const r = await fetch(`${API_URL}/api/v1/appointments/list`, {
+      headers: { 'Authorization': `Bearer ${token}` }
+    });
+    if (!r.ok) return;
+    const d = await r.json();
+    d.appointments.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+    d.appointments.forEach(ap => {
+      const btn = document.createElement('button');
+      btn.className = 'secondary';
+      btn.textContent = `${new Date(ap.created_at).toLocaleString()} - ${ap.status}`;
+      btn.onclick = () => openAppointment(ap.appointment_id, ap.status);
+      appointmentsEl.appendChild(btn);
+    });
+  } catch (e) {}
 }
-function stopRecording(){
-    if(recorder){
-        recorder.stop();
-        isRecording=false;
-        recordBtn.textContent='Запись';
-    }
+
+createBtn.onclick = async () => {
+  try {
+    const r = await fetch(`${API_URL}/api/v1/appointments/create`, {
+      method: 'POST',
+      headers: { 'Authorization': `Bearer ${token}` }
+    });
+    if (!r.ok) throw new Error();
+    const d = await r.json();
+    openAppointment(d.appointment_id, 'pending');
+  } catch (e) {
+    alert('Ошибка создания приема');
+  }
+};
+
+backBtn.onclick = () => {
+  appointmentEl.classList.add('hidden');
+  appointmentsEl.classList.remove('hidden');
+  fetchAppointments();
+};
+
+async function openAppointment(id, status) {
+  currentAppointment = id;
+  currentStatus = status;
+  appointmentTitle.textContent = `Прием ${id.slice(0, 8)}`;
+  appointmentsEl.classList.add('hidden');
+  appointmentEl.classList.remove('hidden');
+  finishBtn.classList.toggle('hidden', status === 'finished');
+  controls.classList.toggle('hidden', status === 'finished');
+  loadRecordings();
 }
-function addRecording(blob){
-    const id=++audioCount;
-    const li=document.createElement('li');
-    const meta=document.createElement('div');
-    meta.className='meta';
-    meta.textContent=`${id}. ${new Date().toLocaleTimeString()}`;
-    const audio=document.createElement('audio');
-    audio.controls=true;
-    audio.src=URL.createObjectURL(blob);
-    const status=document.createElement('span');
-    status.className='status';
-    status.textContent='отправка...';
-    li.appendChild(meta);
-    li.appendChild(audio);
-    li.appendChild(status);
-    recordingsList.prepend(li);
-    sendAudio(id,blob,status);
-}
-function sendAudio(id,blob,statusEl){
-    const fd=new FormData();
-    fd.append('number',id);
-    fd.append('appointment_id',sessionId);
-    fd.append('file',blob,`audio_${id}.webm`);
-    fetch(`${API_URL}/api/v1/audio/upload`,{method:'POST',headers:{'Authorization':`Bearer ${token}`},body:fd})
-        .then(r=>r.ok?r.json():Promise.reject())
-        .then(()=>{statusEl.textContent='отправлено';})
-        .catch(()=>{statusEl.textContent='ошибка';});
-}
-finishBtn.onclick=()=>{
+
+finishBtn.onclick = async () => {
+  try {
+    const fd = new FormData();
+    fd.append('appointment_id', currentAppointment);
+    const r = await fetch(`${API_URL}/api/v1/appointments/finish`, {
+      method: 'POST',
+      headers: { 'Authorization': `Bearer ${token}` },
+      body: fd
+    });
+    if (!r.ok) throw new Error();
+    finishBtn.classList.add('hidden');
     controls.classList.add('hidden');
-    startBtn.classList.remove('hidden');
-    recordingsList.innerHTML='';
-    alert('Прием завершен');
+    fetchAppointments();
+  } catch (e) {
+    alert('Ошибка завершения');
+  }
 };
-recordBtn.addEventListener('pointerdown',e=>{
-    recordBtn.setPointerCapture(e.pointerId);
-    holdTimer=setTimeout(()=>{startRecording();recordBtn.dataset.mode='hold';},200);
+
+function startRecording() {
+  navigator.mediaDevices.getUserMedia({ audio: true }).then(stream => {
+    recorder = new MediaRecorder(stream);
+    recorder.ondataavailable = e => { chunks.push(e.data); };
+    recorder.onstop = () => {
+      const blob = new Blob(chunks, { type: 'audio/webm' });
+      chunks = [];
+      uploadRecording(blob);
+    };
+    recorder.start();
+    isRecording = true;
+    recordBtn.textContent = 'Стоп';
+  }).catch(() => alert('Нет доступа к микрофону'));
+}
+
+function stopRecording() {
+  if (recorder) {
+    recorder.stop();
+    isRecording = false;
+    recordBtn.textContent = 'Запись';
+  }
+}
+
+recordBtn.addEventListener('pointerdown', e => {
+  recordBtn.setPointerCapture(e.pointerId);
+  holdTimer = setTimeout(() => { startRecording(); recordBtn.dataset.mode = 'hold'; }, 200);
 });
-recordBtn.addEventListener('pointerup',e=>{
-    clearTimeout(holdTimer);
-    recordBtn.releasePointerCapture(e.pointerId);
-    if(recordBtn.dataset.mode==='hold'){
-        if(isRecording)stopRecording();
-        recordBtn.dataset.mode='';
-    }else{
-        if(!isRecording)startRecording();
-        else stopRecording();
-    }
+recordBtn.addEventListener('pointerup', e => {
+  clearTimeout(holdTimer);
+  recordBtn.releasePointerCapture(e.pointerId);
+  if (recordBtn.dataset.mode === 'hold') {
+    if (isRecording) stopRecording();
+    recordBtn.dataset.mode = '';
+  } else {
+    if (!isRecording) startRecording(); else stopRecording();
+  }
 });
-if('serviceWorker' in navigator && location.protocol.startsWith('http')){
-    navigator.serviceWorker.register('./sw.js');
+
+function uploadRecording(blob) {
+  const fd = new FormData();
+  fd.append('number', audioCount + 1);
+  fd.append('appointment_id', currentAppointment);
+  fd.append('file', blob, `audio_${Date.now()}.webm`);
+  const status = document.createElement('span');
+  status.className = 'status';
+  status.textContent = 'отправка...';
+  recordingsList.prepend(status);
+  fetch(`${API_URL}/api/v1/appointments/audio/upload`, {
+    method: 'POST',
+    headers: { 'Authorization': `Bearer ${token}` },
+    body: fd
+  }).then(r => r.ok ? r.json() : Promise.reject()).then(() => {
+    status.remove();
+    loadRecordings();
+  }).catch(() => { status.textContent = 'ошибка'; });
+}
+
+async function loadRecordings() {
+  recordingsList.innerHTML = '';
+  audioCount = 0;
+  try {
+    const r = await fetch(`${API_URL}/api/v1/appointments/audio/list?appointment_id=${currentAppointment}`, {
+      headers: { 'Authorization': `Bearer ${token}` }
+    });
+    if (!r.ok) return;
+    const d = await r.json();
+    d.audio_files.forEach(f => { audioCount++; addExisting(f); });
+  } catch (e) {}
+}
+
+function addExisting(f) {
+  const li = document.createElement('li');
+  const meta = document.createElement('div');
+  meta.className = 'meta';
+  meta.textContent = `${f.audio_id}. ${new Date(f.created_at).toLocaleTimeString()}`;
+  const txt = document.createElement('button');
+  txt.className = 'text-btn';
+  txt.textContent = '📝';
+  txt.onclick = () => alert(f.transcript || '');
+  meta.appendChild(txt);
+  li.appendChild(meta);
+  const audio = document.createElement('audio');
+  audio.controls = true;
+  audio.src = `${API_URL}/api/v1/appointments/audio/get?appointment_id=${currentAppointment}&audio_id=${f.audio_id}`;
+  li.appendChild(audio);
+  if (currentStatus !== 'finished') {
+    const del = document.createElement('button');
+    del.className = 'text-btn';
+    del.textContent = '✖';
+    del.onclick = () => deleteAudio(f.audio_id, li);
+    li.appendChild(del);
+  }
+  recordingsList.appendChild(li);
+}
+
+async function deleteAudio(id, el) {
+  try {
+    const r = await fetch(`${API_URL}/api/v1/appointments/audio/delete?appointment_id=${currentAppointment}&audio_id=${id}`, {
+      headers: { 'Authorization': `Bearer ${token}` }
+    });
+    if (r.ok) el.remove();
+  } catch (e) {}
+}
+
+if ('serviceWorker' in navigator && location.protocol.startsWith('http')) {
+  navigator.serviceWorker.register('./sw.js');
 }

--- a/assets/style.css
+++ b/assets/style.css
@@ -8,6 +8,9 @@ button.primary{background:#6200ee;color:#fff}
 button.secondary{background:#f5f5f5}
 #login input,#login button{width:100%;padding:8px;margin:10px 0;box-sizing:border-box}
 .hidden{display:none}
+header{display:flex;justify-content:space-between;align-items:center;margin-bottom:10px}
+button.record-btn{font-size:1.2em;padding:20px}
+button.text-btn{background:none;border:none;cursor:pointer;padding:0 5px}
 ul{list-style:none;padding:0;margin-top:15px;overflow-y:auto;flex:1}
 li{margin-bottom:10px}
 audio{width:100%}

--- a/index.html
+++ b/index.html
@@ -20,11 +20,22 @@
             <button id="loginBtn" type="submit" class="primary">Войти</button>
         </form>
     </div>
-    <div id="session" class="hidden">
-        <button id="startBtn" class="primary">Начать прием</button>
-        <div id="controls" class="hidden">
-            <button id="recordBtn" class="primary">Запись</button>
-            <button id="finishBtn" class="secondary">Закончить прием</button>
+    <div id="app" class="hidden">
+        <header>
+            <span id="username"></span>
+            <button id="logoutBtn" class="secondary">Выход</button>
+        </header>
+        <div id="menu">
+            <button id="createBtn" class="primary">Новый прием</button>
+        </div>
+        <div id="appointments"></div>
+        <div id="appointment" class="hidden">
+            <button id="backBtn" class="secondary">Назад</button>
+            <h2 id="appointmentTitle"></h2>
+            <button id="finishBtn" class="secondary hidden">Завершить прием</button>
+            <div id="controls" class="hidden">
+                <button id="recordBtn" class="primary record-btn">Запись</button>
+            </div>
             <ul id="recordings"></ul>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- redesign interface to show user info and appointment list after login
- allow starting, viewing and finishing appointments
- make record button larger and add transcript and delete actions for each audio

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_b_685db6fa0134832db4ef19323c66993e