### PR TITLE
Ensure PWA updates after each deploy

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -292,7 +292,7 @@ async function deleteAudio(id, el) {
 }
 
 if ('serviceWorker' in navigator && location.protocol.startsWith('http')) {
-  navigator.serviceWorker.register('./sw.js');
+  navigator.serviceWorker.register('./sw.js', { updateViaCache: 'none' });
 }
 
 });

--- a/sw.js
+++ b/sw.js
@@ -1,11 +1,38 @@
-self.addEventListener('install',e=>{
+const CACHE_NAME = 'clinic-cache-v1';
+
+self.addEventListener('install', event => {
   self.skipWaiting();
-  e.waitUntil(
-    caches.open('v1').then(c=>c.addAll(['./']))
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache =>
+      cache.addAll([
+        './',
+        './index.html',
+        './assets/style.css',
+        './assets/main.js',
+        './manifest.json',
+        './favicon.svg'
+      ])
+    )
   );
 });
-self.addEventListener('fetch',e=>{
-  e.respondWith(
-    caches.match(e.request).then(r=>r||fetch(e.request))
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.filter(k => k !== CACHE_NAME).map(k => caches.delete(k)))
+    )
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    fetch(event.request)
+      .then(response => {
+        const clone = response.clone();
+        caches.open(CACHE_NAME).then(cache => cache.put(event.request, clone));
+        return response;
+      })
+      .catch(() => caches.match(event.request))
   );
 });


### PR DESCRIPTION
## Summary
- revise service worker to clear old caches and use a network-first strategy
- register service worker without using the HTTP cache

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685fc0afa3fc832d90eca8b0b477a0ac