### PR TITLE
Update UI to show appointment number and transcripts

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -120,11 +120,11 @@ async function fetchAppointments() {
     if (!r.ok) return;
     const d = await r.json();
     d.appointments.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
-    d.appointments.forEach(ap => {
+    d.appointments.forEach((ap, idx) => {
       const btn = document.createElement('button');
       btn.className = 'secondary';
-      btn.textContent = `${new Date(ap.created_at).toLocaleString()} - ${translateStatus(ap.status)}`;
-      btn.onclick = () => openAppointment(ap.appointment_id, ap.status);
+      btn.textContent = `Прием ${idx + 1}: ${new Date(ap.created_at).toLocaleString()} - ${translateStatus(ap.status)}`;
+      btn.onclick = () => openAppointment(ap.appointment_id, ap.status, idx + 1);
       appointmentsEl.appendChild(btn);
     });
   } catch (e) {
@@ -153,9 +153,15 @@ backBtn.onclick = () => {
   fetchAppointments();
 };
 
-async function openAppointment(id, status) {
+async function openAppointment(id, status, number = null) {
   currentAppointment = id;
   currentStatus = status;
+  const title = document.getElementById('appointmentTitle');
+  if (number !== null) {
+    title.textContent = `Прием ${number}`;
+  } else {
+    title.textContent = '';
+  }
   createBtn.classList.add('hidden');
   appointmentsEl.classList.add('hidden');
   appointmentEl.classList.remove('hidden');
@@ -273,11 +279,6 @@ function addExisting(f) {
   const time = document.createElement('span');
   time.textContent = `${f.audio_id}. ${new Date(f.created_at).toLocaleTimeString()}`;
   meta.appendChild(time);
-  const txt = document.createElement('button');
-  txt.className = 'secondary';
-  txt.textContent = 'текст';
-  txt.onclick = () => alert(f.transcript || '');
-  meta.appendChild(txt);
   if (currentStatus !== 'finished') {
     const spacer = document.createElement('span');
     spacer.className = 'spacer';
@@ -295,6 +296,12 @@ function addExisting(f) {
     if (e.message === 'unauthorized') retryQueue.push(loadRecordings);
   });
   li.appendChild(audio);
+  if (f.transcript) {
+    const text = document.createElement('div');
+    text.className = 'transcript';
+    text.textContent = f.transcript;
+    li.appendChild(text);
+  }
   recordingsList.appendChild(li);
 }
 

--- a/assets/style.css
+++ b/assets/style.css
@@ -3,6 +3,7 @@ body.logged-in{align-items:flex-start;padding-top:20px;height:100vh;overflow:hid
 .container{background:#fff;padding:20px;margin:0 0 20px;border-radius:8px;box-shadow:0 2px 8px rgba(0,0,0,0.1);width:300px}
 body.logged-in .container{display:flex;flex-direction:column;height:calc(100vh - 80px)}
 h1{text-align:center;font-size:1.4em;margin-bottom:20px}
+h2{font-size:1.2em;margin:10px 0}
 button{font-size:1em;padding:10px 20px;margin:5px;width:100%;border:none;border-radius:4px;cursor:pointer}
 button.primary{background:#6200ee;color:#fff}
 button.secondary{background:#f5f5f5}
@@ -18,7 +19,8 @@ button.text-btn{background:none;border:none;cursor:pointer;padding:0 5px;font-si
 button.danger{background:#e53935;color:#fff}
 button.record-btn{font-size:1.2em;padding:20px}
 ul{list-style:none;padding:0;margin-top:15px;overflow-y:auto;flex:1}
-li{margin-bottom:10px}
+li{margin-bottom:10px;padding-bottom:10px;border-bottom:1px solid #ddd}
 audio{width:100%}
 .status{font-size:0.8em;color:#666}
 #controls{position:sticky;top:0;background:#fff;z-index:1}
+.transcript{font-size:0.9em;margin-top:5px;color:#333}

--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
         <div id="appointment" class="hidden">
             <button id="backBtn" class="secondary">Назад</button>
             <button id="finishBtn" class="secondary hidden">Завершить прием</button>
+            <h2 id="appointmentTitle"></h2>
             <div id="controls" class="hidden">
                 <button id="recordBtn" class="primary record-btn">Запись</button>
             </div>


### PR DESCRIPTION
## Summary
- show appointment number instead of ID in the list and header
- display transcript text under each recording
- add horizontal separators between recordings

## Testing
- `node -c assets/main.js`

------
https://chatgpt.com/codex/tasks/task_b_685fdf36a5fc832da9d99b74c043e788