### PR TITLE
Reverse audio order inside appointment

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -239,7 +239,7 @@ function uploadRecording(blob) {
   const status = document.createElement('span');
   status.className = 'status';
   status.textContent = 'отправка...';
-  recordingsList.prepend(status);
+  recordingsList.appendChild(status);
   apiFetch(`${API_URL}/api/v1/appointments/audio/upload`, {
     method: 'POST',
     body: fd

--- a/assets/style.css
+++ b/assets/style.css
@@ -18,7 +18,7 @@ header button{width:auto;margin:0;padding:5px 10px}
 button.text-btn{background:none;border:none;cursor:pointer;padding:0 5px;font-size:1.3em}
 button.danger{background:#e53935;color:#fff}
 button.record-btn{font-size:1.2em;padding:20px}
-ul{list-style:none;padding:0;margin-top:15px;overflow-y:auto;flex:1}
+ul{list-style:none;padding:0;margin-top:15px;overflow-y:auto;flex:1;display:flex;flex-direction:column-reverse}
 li{margin-bottom:10px;padding-bottom:10px;border-bottom:1px solid #ddd}
 audio{width:100%}
 .status{font-size:0.8em;color:#666}


### PR DESCRIPTION
## Summary
- make the recordings list use column-reverse order so new files appear first
- adjust upload status placement to work with reversed list

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6861a23a5f94832da2fe627b88f83329