### PR TITLE
Add background polling for audio updates

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -56,6 +56,8 @@ let audioCount = 0;
 let isRecording = false;
 let holdTimer = null;
 const retryQueue = [];
+let audioPollInterval = null;
+let lastAudioSnapshot = null;
 
 function showApp() {
   loginEl.classList.add('hidden');
@@ -180,6 +182,7 @@ loginForm.onsubmit = async (e) => {
 };
 
 logoutBtn.onclick = () => {
+  stopAudioPolling();
   token = null;
   currentUser = null;
   localStorage.removeItem('token');
@@ -224,6 +227,7 @@ createBtn.onclick = async function createAppointment() {
 };
 
 backBtn.onclick = () => {
+  stopAudioPolling();
   appointmentEl.classList.add('hidden');
   appointmentsEl.classList.remove('hidden');
   createBtn.classList.remove('hidden');
@@ -245,6 +249,7 @@ async function openAppointment(id, status, number = null) {
   finishBtn.classList.toggle('hidden', status === 'finished');
   controls.classList.toggle('hidden', status === 'finished');
   loadRecordings();
+  startAudioPolling();
 }
 
 finishBtn.onclick = async function finishAppointment() {
@@ -258,6 +263,7 @@ finishBtn.onclick = async function finishAppointment() {
     if (!r.ok) throw new Error();
     finishBtn.classList.add('hidden');
     controls.classList.add('hidden');
+    stopAudioPolling();
     fetchAppointments();
     location.reload();
   } catch (e) {
@@ -334,20 +340,52 @@ function uploadRecording(blob) {
   });
 }
 
-async function loadRecordings() {
+function renderRecordings(files) {
   recordingsList.innerHTML = '';
   audioCount = 0;
+  files.sort((a, b) => a.audio_id - b.audio_id).forEach(f => {
+    audioCount = Math.max(audioCount, f.audio_id);
+    addExisting(f);
+  });
+  recordingsList.scrollTop = recordingsList.scrollHeight;
+}
+
+async function loadRecordings() {
   try {
     const r = await apiFetch(`${API_URL}/api/v1/appointments/audio/list?appointment_id=${currentAppointment}`);
     if (!r.ok) return;
     const d = await r.json();
-    d.audio_files.sort((a, b) => a.audio_id - b.audio_id).forEach(f => {
-      audioCount = Math.max(audioCount, f.audio_id);
-      addExisting(f);
-    });
-    recordingsList.scrollTop = recordingsList.scrollHeight;
+    renderRecordings(d.audio_files);
+    lastAudioSnapshot = JSON.stringify(d.audio_files);
   } catch (e) {
     if (e.message === 'unauthorized') retryQueue.push(loadRecordings);
+  }
+}
+
+async function checkAudioUpdates() {
+  try {
+    const r = await apiFetch(`${API_URL}/api/v1/appointments/audio/list?appointment_id=${currentAppointment}`);
+    if (!r.ok) return;
+    const d = await r.json();
+    const snapshot = JSON.stringify(d.audio_files);
+    if (snapshot !== lastAudioSnapshot) {
+      lastAudioSnapshot = snapshot;
+      renderRecordings(d.audio_files);
+    }
+  } catch (e) {
+    if (e.message === 'unauthorized') retryQueue.push(checkAudioUpdates);
+  }
+}
+
+function startAudioPolling() {
+  stopAudioPolling();
+  audioPollInterval = setInterval(checkAudioUpdates, 5000);
+}
+
+function stopAudioPolling() {
+  if (audioPollInterval) {
+    clearInterval(audioPollInterval);
+    audioPollInterval = null;
   }
 }
 


### PR DESCRIPTION
## Summary
- add new rendering logic to update the audio list only when the backend list changes
- poll the backend every 5s using `checkAudioUpdates`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_68659dc52ffc832d8a3aed15f34d4ef2