### PR TITLE
Display generated reports without modal

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -49,8 +49,6 @@ document.addEventListener('DOMContentLoaded', () => {
   const reportDialog = document.getElementById('reportDialog');
   const reportMainBtn = document.getElementById('reportMainBtn');
   const reportAnamnesisBtn = document.getElementById('reportAnamnesisBtn');
-  const reportReadyDialog = document.getElementById('reportReadyDialog');
-  const reportDownloadLink = document.getElementById('reportDownloadLink');
 
   function translateStatus(status) {
     switch (status) {
@@ -106,14 +104,6 @@ function hideReportDialog() {
   reportDialog.classList.add('hidden');
 }
 
-function showReportReadyDialog(url) {
-  reportDownloadLink.href = url;
-  reportReadyDialog.classList.remove('hidden');
-}
-
-function hideReportReadyDialog() {
-  reportReadyDialog.classList.add('hidden');
-}
 
 async function requestReport(type) {
   hideReportDialog();
@@ -121,9 +111,9 @@ async function requestReport(type) {
   try {
     const r = await apiFetch(`${API_URL}/api/v1/appointments/report?appointment_id=${currentAppointment}&report_type=${type}`);
     if (!r.ok) throw new Error();
-    const d = await r.json();
-    if (!d.report_url) throw new Error();
-    showReportReadyDialog(d.report_url);
+    const blob = await r.blob();
+    const url = URL.createObjectURL(blob);
+    window.open(url, '_blank');
   } catch (e) {
     alert('Ошибка получения отчета');
   } finally {
@@ -469,7 +459,6 @@ reportBtn.onclick = () => {
 
 reportMainBtn.onclick = () => requestReport('main');
 reportAnamnesisBtn.onclick = () => requestReport('anamnesis');
-reportDownloadLink.onclick = () => hideReportReadyDialog();
 
 if ('serviceWorker' in navigator && location.protocol.startsWith('http')) {
   navigator.serviceWorker.register('./sw.js', { updateViaCache: 'none' });

--- a/index.html
+++ b/index.html
@@ -51,12 +51,6 @@
             <button id="reportAnamnesisBtn" class="primary">Анамнез</button>
         </div>
     </div>
-    <div id="reportReadyDialog" class="dialog hidden">
-        <div class="dialog-content">
-            <p>Отчет готов</p>
-            <a id="reportDownloadLink" href="#" target="_blank">Скачать</a>
-        </div>
-    </div>
     <script src="assets/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove the report download dialog
- open returned PDF immediately when requesting a report

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_68663c8f8e0c832d814b3621dcce7b1f