### PR TITLE
Improve recording UX

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -359,6 +359,7 @@ function uploadRecording(blob, mimeType) {
   status.className = 'status';
   status.textContent = 'отправка...';
   recordingsList.appendChild(status);
+  recordingsList.scrollTop = recordingsList.scrollHeight;
   apiFetch(`${API_URL}/api/v1/appointments/audio/upload`, {
     method: 'POST',
     body: fd

--- a/assets/style.css
+++ b/assets/style.css
@@ -4,7 +4,7 @@ body.logged-in{align-items:flex-start;padding-top:20px;height:100vh;overflow:hid
 body.logged-in .container{display:flex;flex-direction:column;height:calc(100vh - 80px)}
 h1{text-align:center;font-size:1.4em;margin-bottom:20px}
 h2{font-size:1.2em;margin:10px 0}
-button{font-size:1em;padding:10px 20px;margin:5px;width:100%;border:none;border-radius:4px;cursor:pointer}
+button{font-size:1em;padding:10px 20px;margin:5px;width:100%;border:none;border-radius:4px;cursor:pointer;user-select:none;-webkit-user-select:none}
 button.primary{background:#6200ee;color:#fff}
 button.secondary{background:#f5f5f5}
 #login input,#login button{width:100%;padding:8px;margin:10px 0;box-sizing:border-box}
@@ -22,7 +22,7 @@ button.record-btn{font-size:1.2em;padding:20px}
 ul{list-style:none;padding:0;margin-top:15px;overflow-y:auto;flex:1;display:flex;flex-direction:column;max-height: 100%}
 li{margin-bottom:10px;padding-bottom:10px;border-bottom:1px solid #ddd}
 audio{width:100%}
-.status{font-size:0.8em;color:#666}
+.status{font-size:1.1em;color:#666}
 #controls{position:sticky;top:0;background:#fff;z-index:1}
 .transcript{font-size:0.9em;margin-top:5px;color:#333}
 .dialog,#loader{position:fixed;top:0;left:0;width:100vw;height:100vh;display:flex;justify-content:center;align-items:center;z-index:1000}


### PR DESCRIPTION
## Summary
- enlarge upload status text and disable user-select on buttons
- keep recordings scrolled to bottom while uploading

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_6866da3a06e4832d8fac2e0480d4d037